### PR TITLE
Switch to Google Sign-In for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Converted from the single-file HTML application into a FastAPI + PostgreSQL back
 
 ## Setup
 
-1. Create a virtual environment and install dependencies:
+1. Create a virtual environment and install dependencies (this installs the required `google-auth` package for Gmail sign-in):
 
    ```bash
    python -m venv .venv
@@ -41,6 +41,12 @@ Google authentication is required for all users. Configure a Google Identity Ser
 client and set `GOOGLE_CLIENT_ID` to the OAuth 2.0 Client ID. Set `GOOGLE_SUPERUSER_EMAIL`
 to the Gmail account that should become the first administrator; that account can then
 invite additional Gmail users and assign roles.
+
+### Troubleshooting Google authentication imports
+
+If the application logs show `ModuleNotFoundError: No module named 'google'`, the deployment
+is missing the Google authentication dependency. Install it by running `pip install -r requirements.txt`
+or `pip install google-auth` in the environment before starting the server.
 
 ### Updating Tailwind styles
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Converted from the single-file HTML application into a FastAPI + PostgreSQL back
 
    ```bash
    cp .env.example .env
-   # edit DATABASE_URL and SESSION_SECRET as needed
+   # edit DATABASE_URL, SESSION_SECRET, GOOGLE_CLIENT_ID, and GOOGLE_SUPERUSER_EMAIL as needed
    ```
 
 3. Run migrations and seed default data:
@@ -37,7 +37,10 @@ Converted from the single-file HTML application into a FastAPI + PostgreSQL back
    uvicorn app.main:app --reload
    ```
 
-The default administrator account is `Admin` / `adminthegreat`.
+Google authentication is required for all users. Configure a Google Identity Services
+client and set `GOOGLE_CLIENT_ID` to the OAuth 2.0 Client ID. Set `GOOGLE_SUPERUSER_EMAIL`
+to the Gmail account that should become the first administrator; that account can then
+invite additional Gmail users and assign roles.
 
 ### Updating Tailwind styles
 

--- a/app/api/v1/bootstrap.py
+++ b/app/api/v1/bootstrap.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.deps import get_current_user, get_db
 from app.models.category import CategoryGroup, SubCategory
 from app.models.metric import Metric
@@ -75,4 +76,5 @@ def bootstrap(db: Session = Depends(get_db), current_user: User = Depends(get_cu
         "locations": location_payload,
         "warehouses": location_payload,
         "sessions": [{"id": str(s.id), "code": s.code, "name": s.name} for s in sessions],
+        "superuser_email": settings.google_superuser_email,
     }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -15,6 +15,8 @@ class Settings:
     database_url: str
     session_secret: str
     entry_event_queue_size: int
+    google_client_id: str
+    google_superuser_email: str
 
     def __init__(self) -> None:
         self.database_url = os.getenv(
@@ -28,6 +30,8 @@ class Settings:
         except ValueError:
             queue_size = 512
         self.entry_event_queue_size = max(0, min(queue_size, 100000))
+        self.google_client_id = os.getenv("GOOGLE_CLIENT_ID", "").strip()
+        self.google_superuser_email = os.getenv("GOOGLE_SUPERUSER_EMAIL", "").strip()
 
 
 @lru_cache()

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,8 @@ app.add_middleware(SessionMiddleware, secret_key=settings.session_secret, same_s
 
 static_dir = Path(__file__).parent / "static"
 templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+templates.env.globals["superuser_email"] = settings.google_superuser_email
+templates.env.globals["google_client_id"] = settings.google_client_id
 
 app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
@@ -49,7 +51,14 @@ def root(request: Request):
 
 @app.get("/login", response_class=HTMLResponse)
 def login_page(request: Request):
-    return templates.TemplateResponse("login.html", {"request": request})
+    return templates.TemplateResponse(
+        "login.html",
+        {
+            "request": request,
+            "google_client_id": settings.google_client_id,
+            "superuser_email": settings.google_superuser_email,
+        },
+    )
 
 
 @app.get("/dashboard", response_class=HTMLResponse)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -16,6 +16,7 @@ class User(Base):
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     username: Mapped[str] = mapped_column(String(60), unique=True, nullable=False)
     password: Mapped[str] = mapped_column(String(255), nullable=False)
+    google_sub: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True)
 
     role_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("roles.id"), nullable=False)
     parent_admin_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
@@ -25,3 +26,7 @@ class User(Base):
 
     role = relationship("app.models.role.Role", backref="users", lazy="joined")
     parent_admin = relationship("User", remote_side="User.id", backref="team_members")
+
+    @property
+    def has_google_login(self) -> bool:
+        return bool(self.google_sub)

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -4,8 +4,7 @@ from pydantic import BaseModel
 
 
 class LoginRequest(BaseModel):
-    username: str
-    password: str
+    credential: str
 
 
 class AuthResponse(BaseModel):

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -15,22 +15,26 @@ class UserBase(BaseModel):
     dashboard_share_enabled: bool = False
 
 
-class UserCreate(UserBase):
-    password: str
+class UserCreate(BaseModel):
+    username: str
+    name: Optional[str] = None
     role_id: uuid.UUID
+    is_active: bool = True
+    dashboard_share_enabled: bool = False
 
 
 class UserUpdate(BaseModel):
     name: Optional[str] = None
-    password: Optional[str] = None
     role_id: Optional[uuid.UUID] = None
     is_active: Optional[bool] = None
     dashboard_share_enabled: Optional[bool] = None
+    reset_google_link: Optional[bool] = None
 
 
 class UserOut(UserBase):
     id: uuid.UUID
     role: RoleOut
     parent_admin_id: Optional[uuid.UUID]
+    has_google_login: bool
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -1,15 +1,159 @@
 from __future__ import annotations
 
+from secrets import token_urlsafe
+from typing import Any
+
 from fastapi import HTTPException, status
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from loginpage import authenticate
+from loginpage import hash_password
 
+from app.core.config import settings
+from app.core.deps import ADMIN_ROLE_NAME
+from app.models.role import Role
+from app.models.user import User
 from app.schemas.auth import LoginRequest
 
 
-def login(db: Session, payload: LoginRequest):
-    user = authenticate(db, payload.username, payload.password)
+GOOGLE_ISSUERS = {"accounts.google.com", "https://accounts.google.com"}
+GMAIL_DOMAINS = {"gmail.com", "googlemail.com"}
+
+
+def _get_admin_role(db: Session) -> Role | None:
+    return db.query(Role).filter(func.lower(Role.name) == ADMIN_ROLE_NAME).one_or_none()
+
+
+def _provision_superuser(db: Session, email: str, google_sub: str, profile: dict[str, Any]) -> User:
+    admin_role = _get_admin_role(db)
+    if not admin_role:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Administrator role is not configured.",
+        )
+
+    display_name = (profile.get("name") or "").strip() or email
+    user = User(
+        username=email,
+        name=display_name,
+        password=hash_password(token_urlsafe(32)),
+        role_id=admin_role.id,
+        is_active=True,
+        dashboard_share_enabled=True,
+        google_sub=google_sub,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _verify_credential(credential: str) -> dict[str, Any]:
+    client_id = settings.google_client_id
+    if not client_id:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Google authentication is not configured.",
+        )
+    try:
+        id_info = id_token.verify_oauth2_token(
+            credential,
+            google_requests.Request(),
+            client_id,
+        )
+    except ValueError as exc:  # pragma: no cover - library raises ValueError on invalid token
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Google credential.",
+        ) from exc
+
+    if id_info.get("iss") not in GOOGLE_ISSUERS:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Untrusted Google issuer.",
+        )
+    if not id_info.get("email_verified"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Your Google email must be verified.",
+        )
+    return id_info
+
+
+def login(db: Session, payload: LoginRequest) -> User:
+    credential = (payload.credential or "").strip()
+    if not credential:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing Google credential.",
+        )
+
+    id_info = _verify_credential(credential)
+    email_raw = (id_info.get("email") or "").strip()
+    email = email_raw.casefold()
+    if not email or "@" not in email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Google credential.",
+        )
+
+    domain = email.split("@", 1)[1]
+    if domain not in GMAIL_DOMAINS:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="A Gmail account is required.",
+        )
+
+    google_sub = id_info.get("sub")
+    if not google_sub:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Google credential.",
+        )
+
+    superuser_email = settings.google_superuser_email.strip().casefold() if settings.google_superuser_email else ""
+
+    user = (
+        db.query(User)
+        .filter(func.lower(User.username) == email)
+        .one_or_none()
+    )
+
     if not user:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        if superuser_email and email == superuser_email:
+            return _provision_superuser(db, email, google_sub, id_info)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have access. Please contact your administrator.",
+        )
+
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Your account is inactive. Please contact your administrator.",
+        )
+
+    if user.google_sub and user.google_sub != google_sub:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This Google account is not linked to your profile.",
+        )
+
+    updated = False
+    if not user.google_sub:
+        user.google_sub = google_sub
+        updated = True
+
+    display_name = (id_info.get("name") or "").strip()
+    if display_name and (not user.name or user.name.strip().casefold() == user.username.casefold()):
+        user.name = display_name
+        updated = True
+
+    if updated:
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
     return user

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -4,6 +4,13 @@ from secrets import token_urlsafe
 from typing import Any
 
 from fastapi import HTTPException, status
+import importlib.util
+
+if importlib.util.find_spec("google.oauth2") is None:
+    raise RuntimeError(
+        "google-auth is not installed. Install dependencies with 'pip install -r requirements.txt' or 'pip install google-auth'."
+    )
+
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token
 from sqlalchemy import func

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,7 +11,10 @@
 </head>
 <body class="text-slate-800">
     {% block content %}{% endblock %}
-    <script>window.__API_BASE__ = "/api/v1";</script>
+    <script>
+      window.__API_BASE__ = "/api/v1";
+      window.__SUPERUSER_EMAIL__ = {{ (superuser_email or '')|tojson }};
+    </script>
     <script src="{{ url_for('static', path='js/app.js') }}" defer></script>
     {% block extra_js %}{% endblock %}
 </body>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -37,25 +37,16 @@
         <p class="text-sm text-slate-600">Secure access with your Google Workspace or Gmail account.</p>
       </div>
       {% if google_client_id %}
-      <div class="space-y-4">
-        <div id="g_id_onload"
-             data-client_id="{{ google_client_id }}"
-             data-context="signin"
-             data-ux_mode="popup"
-             data-callback="handleGoogleCredential"
-             data-itp_support="true"></div>
-        <div class="g_id_signin"
-             data-type="standard"
-             data-shape="pill"
-             data-theme="filled_blue"
-             data-text="signin_with"
-             data-size="large"
-             data-logo_alignment="left"></div>
+      <div class="space-y-5">
+        <div class="grid gap-3">
+          <div id="google-signin"></div>
+          <div id="google-signup"></div>
+        </div>
         <div class="flex flex-col gap-3 text-sm text-slate-500 text-center">
-          <p>Need access? Ask your administrator for an invite.</p>
+          <p>Use your authorized Gmail account to sign in or sign up.</p>
           {% if superuser_email %}
           <a id="request-access" class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 px-4 py-2 font-semibold text-slate-600 hover:bg-slate-50 transition" href="mailto:{{ superuser_email }}?subject=Hermas%20Stock%20Taker%20Access&body=Hi%2C%20please%20invite%20me%20to%20Hermas%20Stock%20Taker.">
-            Request an invite
+            Need an invite? Contact the admin
           </a>
           {% endif %}
         </div>
@@ -125,6 +116,7 @@ animateOcean();
 
 const statusEl = document.getElementById('status');
 const errorEl = document.getElementById('error');
+const googleClientId = {{ google_client_id|tojson }};
 
 function setStatus(message) {
   if (!statusEl) return;
@@ -173,12 +165,73 @@ async function postCredential(credential) {
   }
 }
 
-window.handleGoogleCredential = function handleGoogleCredential(response) {
+function handleGoogleCredential(response) {
   if (!response || !response.credential) {
     showError('Invalid Google response.');
     return;
   }
   postCredential(response.credential);
-};
+}
+
+function initializeGoogleSignIn() {
+  if (!googleClientId || !window.google || !window.google.accounts || !window.google.accounts.id) {
+    return false;
+  }
+
+  window.google.accounts.id.initialize({
+    client_id: googleClientId,
+    callback: handleGoogleCredential,
+    ux_mode: 'popup',
+    context: 'signin',
+  });
+
+  const signInContainer = document.getElementById('google-signin');
+  if (signInContainer && !signInContainer.hasChildNodes()) {
+    window.google.accounts.id.renderButton(signInContainer, {
+      type: 'standard',
+      shape: 'pill',
+      theme: 'filled_blue',
+      text: 'signin_with',
+      size: 'large',
+      logo_alignment: 'left',
+    });
+  }
+
+  const signUpContainer = document.getElementById('google-signup');
+  if (signUpContainer && !signUpContainer.hasChildNodes()) {
+    window.google.accounts.id.renderButton(signUpContainer, {
+      type: 'standard',
+      shape: 'pill',
+      theme: 'outline',
+      text: 'signup_with',
+      size: 'large',
+      logo_alignment: 'left',
+    });
+  }
+
+  return true;
+}
+
+function waitForGoogle(initAttempts = 0) {
+  if (initializeGoogleSignIn()) {
+    return;
+  }
+
+  if (initAttempts > 20) {
+    console.warn('Google Sign-In script not loaded.');
+    return;
+  }
+
+  setTimeout(() => waitForGoogle(initAttempts + 1), 150);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  if (!googleClientId) {
+    return;
+  }
+  waitForGoogle();
+});
+
+window.handleGoogleCredential = handleGoogleCredential;
 </script>
 {% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -34,20 +34,39 @@
     <div class="bg-white/80 backdrop-blur-xl p-8 rounded-3xl shadow-2xl space-y-6 border border-white/40">
       <div class="text-center space-y-2">
         <h1 class="text-3xl font-semibold text-slate-800">Hermas Stock Taker</h1>
-        <p class="text-sm text-slate-600">Sign in with your administrator credentials</p>
+        <p class="text-sm text-slate-600">Secure access with your Google Workspace or Gmail account.</p>
       </div>
-      <form id="login-form" class="space-y-5">
-        <div>
-          <label class="block text-sm font-medium text-slate-600 mb-1" for="username">Username</label>
-          <input class="w-full border border-slate-300/70 rounded-xl px-3 py-2.5 bg-white/80 focus:outline-none focus:ring-2 focus:ring-sky-500" id="username" name="username" required />
+      {% if google_client_id %}
+      <div class="space-y-4">
+        <div id="g_id_onload"
+             data-client_id="{{ google_client_id }}"
+             data-context="signin"
+             data-ux_mode="popup"
+             data-callback="handleGoogleCredential"
+             data-itp_support="true"></div>
+        <div class="g_id_signin"
+             data-type="standard"
+             data-shape="pill"
+             data-theme="filled_blue"
+             data-text="signin_with"
+             data-size="large"
+             data-logo_alignment="left"></div>
+        <div class="flex flex-col gap-3 text-sm text-slate-500 text-center">
+          <p>Need access? Ask your administrator for an invite.</p>
+          {% if superuser_email %}
+          <a id="request-access" class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 px-4 py-2 font-semibold text-slate-600 hover:bg-slate-50 transition" href="mailto:{{ superuser_email }}?subject=Hermas%20Stock%20Taker%20Access&body=Hi%2C%20please%20invite%20me%20to%20Hermas%20Stock%20Taker.">
+            Request an invite
+          </a>
+          {% endif %}
         </div>
-        <div>
-          <label class="block text-sm font-medium text-slate-600 mb-1" for="password">Password</label>
-          <input type="password" class="w-full border border-slate-300/70 rounded-xl px-3 py-2.5 bg-white/80 focus:outline-none focus:ring-2 focus:ring-sky-500" id="password" name="password" required />
-        </div>
-        <button class="w-full bg-sky-600 hover:bg-sky-700 text-white rounded-xl py-2.5 font-semibold shadow-lg shadow-sky-600/30 transition" type="submit">Login</button>
-        <p id="error" class="text-sm text-red-600 hidden text-center">Invalid credentials</p>
-      </form>
+        <p id="status" class="text-sm text-slate-500 hidden text-center">Signing you in…</p>
+        <p id="error" class="text-sm text-red-600 hidden text-center">Unable to sign in with Google. Please try again.</p>
+      </div>
+      {% else %}
+      <div class="bg-red-50 border border-red-200 rounded-2xl p-4 text-sm text-red-700 text-center">
+        Google Sign-In is not configured. Please contact your administrator.
+      </div>
+      {% endif %}
     </div>
   </div>
 </div>
@@ -55,6 +74,7 @@
 
 {% block extra_js %}
 {{ super() }}
+<script src="https://accounts.google.com/gsi/client" async defer></script>
 <script>
 const canvas = document.getElementById("login-ocean");
 const ctx = canvas.getContext("2d");
@@ -103,30 +123,62 @@ function animateOcean() {
 }
 animateOcean();
 
-const form = document.getElementById('login-form');
-const error = document.getElementById('error');
-form.addEventListener('submit', async (event) => {
-  event.preventDefault();
-  error.classList.add('hidden');
-  const payload = {
-    username: form.username.value,
-    password: form.password.value,
-  };
+const statusEl = document.getElementById('status');
+const errorEl = document.getElementById('error');
+
+function setStatus(message) {
+  if (!statusEl) return;
+  if (message) {
+    statusEl.textContent = message;
+    statusEl.classList.remove('hidden');
+  } else {
+    statusEl.classList.add('hidden');
+  }
+}
+
+function showError(message) {
+  if (!errorEl) return;
+  errorEl.textContent = message || 'Unable to sign in with Google. Please try again.';
+  errorEl.classList.remove('hidden');
+  setStatus('');
+}
+
+async function postCredential(credential) {
+  if (!credential) {
+    showError('Missing Google credential.');
+    return;
+  }
+  setStatus('Signing you in…');
+  if (errorEl) {
+    errorEl.classList.add('hidden');
+  }
   try {
-    const res = await fetch("/api/v1/auth/login", {
-      method: "POST",
-      headers: {"Content-Type": "application/json"},
-      body: JSON.stringify(payload),
+    const res = await fetch('/api/v1/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ credential }),
     });
     if (res.ok) {
-      window.location.href = "/dashboard";
-    } else {
-      error.classList.remove('hidden');
+      window.location.href = '/dashboard';
+      return;
     }
+    const payload = await res.json().catch(() => ({}));
+    const detail = payload?.detail || 'Your Google account is not authorized.';
+    showError(detail);
   } catch (err) {
     console.error(err);
-    error.classList.remove('hidden');
+    showError('Unable to reach the server. Please try again.');
+  } finally {
+    setStatus('');
   }
-});
+}
+
+window.handleGoogleCredential = function handleGoogleCredential(response) {
+  if (!response || !response.credential) {
+    showError('Invalid Google response.');
+    return;
+  }
+  postCredential(response.credential);
+};
 </script>
 {% endblock %}

--- a/migrations/versions/2025_06_05_120000_enable_google_signin.py
+++ b/migrations/versions/2025_06_05_120000_enable_google_signin.py
@@ -1,0 +1,27 @@
+"""Enable Google-based sign in"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2025_06_05_120000_enable_google_signin"
+down_revision = "2025_05_20_120500_add_items_lower_name_index"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("google_sub", sa.String(length=255), nullable=True))
+    op.create_unique_constraint("uq_users_google_sub", "users", ["google_sub"])
+
+    connection = op.get_bind()
+    connection.execute(sa.text("UPDATE users SET username = lower(username)"))
+    connection.execute(sa.text("UPDATE users SET google_sub = NULL WHERE google_sub = ''"))
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_users_google_sub", "users", type_="unique")
+    op.drop_column("users", "google_sub")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ itsdangerous
 passlib==1.7.4
 openpyxl
 python-multipart
+google-auth


### PR DESCRIPTION
## Summary
- replace username/password authentication with Google Sign-In, including new credential validation service and configuration
- update user management APIs, schemas, and frontend to invite Gmail accounts, reset Google links, and surface linkage status
- add database migration for storing Google subject identifiers and document new environment variables

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dba6b6c6c88320ac76c9eb664461f1